### PR TITLE
chore: ignore python linters other than Ruff

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -64,6 +64,12 @@ jobs:
           VALIDATE_DOCKERFILE_HADOLINT: false
           VALIDATE_JSON: false
           VALIDATE_JSON_PRETTIER: false
+          # Disabling python linters other than Ruff, as per issue #88
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_MYPY: false
+          VALIDATE_PYTHON_PYINK: false
           # Temporarily disable PYTHON_PYLINT to make PR #65 green
           VALIDATE_PYTHON_PYLINT: false
           VALIDATE_SHELL_SHFMT: false


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description

<!-- Add a brief description of the pr -->
Exclude Black, Flake8, ISort, MyPy, PyInk (and PyLint already excluded previously) from super linter action.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #88 
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
