### PR TITLE
Fix Publish Docker Image: pin depthai clone to main branch (#104)

### DIFF
--- a/code/oak-d-lite-module/Dockerfile
+++ b/code/oak-d-lite-module/Dockerfile
@@ -2,7 +2,10 @@ FROM python:3.10-bullseye
 
 RUN apt-get update && apt-get install -y wget build-essential cmake pkg-config libjpeg-dev libtiff5-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev libgtk2.0-dev libgtk-3-dev libatlas-base-dev gfortran git
 
-RUN git clone https://github.com/luxonis/depthai.git depthai
+# Pin to the "main" branch explicitly: upstream changed the repository's
+# default branch to "readme" (docs only), which lacks docker_dependencies.sh
+# and install_requirements.py and broke the unpinned clone. See issue #104.
+RUN git clone --depth 1 --branch main https://github.com/luxonis/depthai.git depthai
 
 RUN ./depthai/docker_dependencies.sh
 


### PR DESCRIPTION
## Summary

Closes #104.

The **Publish Docker Image** workflow fails while building `code/oak-d-lite-module/Dockerfile` at:

```text
#10 [4/9] RUN ./depthai/docker_dependencies.sh
/bin/sh: 1: ./depthai/docker_dependencies.sh: not found  (exit code 127)
```

### Root cause

The Dockerfile clones `luxonis/depthai` **without specifying a branch**. Upstream has since changed the repository's **default branch to `readme`** (a docs-only branch), which does not contain `docker_dependencies.sh` or `install_requirements.py`. The unpinned `git clone` therefore checked out `readme` instead of the maintained depthai v2 demo code, so the expected script was missing.

### Fix

```diff
-RUN git clone https://github.com/luxonis/depthai.git depthai
+# Pin to the "main" branch explicitly: upstream changed the repository's
+# default branch to "readme" (docs only), which lacks docker_dependencies.sh
+# and install_requirements.py and broke the unpinned clone. See issue #104.
+RUN git clone --depth 1 --branch main https://github.com/luxonis/depthai.git depthai
```

`main` still carries both helper scripts and the depthai v2 demo flow this module targets. `--depth 1` keeps the clone shallow for a faster build.

### Verification

- Confirmed `docker_dependencies.sh` exists on `luxonis/depthai` `main` (a valid executable bash script) and is absent from the `readme` default branch.
- Confirmed the change introduces no new `hadolint` findings (`.github/linters/.hadolint.yaml` only ignores `DL3008`).

## Notes

This was originally committed on the #95 refactor branch; it has been split out into this dedicated PR so the Docker-build fix can be reviewed and merged independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc57S5DG9vCz16a8g7Xxqi)_