### PR TITLE
Document GHCR image usage and add compose.yaml (#50)

### DIFF
--- a/code/oak-d-lite-module/README.md
+++ b/code/oak-d-lite-module/README.md
@@ -65,6 +65,51 @@ python3 ./test/test_webserver.py -u <http://server_address:9090/>
 
 This script will attempt to run each of the available models for 30 seconds, and returns the inference results every 1s.
 
+## Running the published image from GHCR
+
+Every push to the `main` branch that touches this module rebuilds the container image and publishes it to the [GitHub Container Registry (GHCR)](https://github.com/orgs/B-AROL-O/packages?repo_name=FREISA) as `ghcr.io/b-arol-o/freisa`, through the [`publish_image.yaml`](../../.github/workflows/publish_image.yaml) workflow. This lets you run the vision server without building the image locally.
+
+Available tags:
+
+- `ghcr.io/b-arol-o/freisa:main` — latest build from the `main` branch
+- `ghcr.io/b-arol-o/freisa:<version>` and `ghcr.io/b-arol-o/freisa:latest` — published when a `v*.*.*` release tag is pushed
+
+Note: the image bundles only the Python dependencies, **not** the module code, models or configuration. Those are mounted into the container at runtime, so run the commands below from **this** directory (`code/oak-d-lite-module/`) and place your model `.blob` files under [`models/`](./models/) first.
+
+If the package is private you first need to authenticate (see [issue #51](https://github.com/B-AROL-O/FREISA/issues/51)):
+
+```bash
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u <your-github-username> --password-stdin
+```
+
+### Using Docker Compose (recommended)
+
+A [`compose.yaml`](./compose.yaml) file is provided. From this directory:
+
+```bash
+docker compose up -d    # pull the image and start the server
+docker compose logs -f  # follow the logs
+docker compose down     # stop and remove the container
+```
+
+### Using docker run
+
+The equivalent of the Compose file above:
+
+```bash
+docker run --rm \
+    --privileged \
+    --name=oak-d-lite-server \
+    -v /dev/bus/usb:/dev/bus/usb \
+    -v .:/oak-d-lite-module/ \
+    --device-cgroup-rule='c 189:* rmw' \
+    -p 9090:9090 \
+    -d \
+    ghcr.io/b-arol-o/freisa:main
+```
+
+As with the locally built image, verify the container started with `docker ps | grep oak-d-lite-server` and query the [HTTP API](#http-api) on port 9090.
+
 ## HTTP API
 
 The web server exposes an HTTP API used to control the OAK-D lite camera.

--- a/code/oak-d-lite-module/compose.yaml
+++ b/code/oak-d-lite-module/compose.yaml
@@ -1,0 +1,36 @@
+---
+# Docker Compose file for the FREISA OAK-D Lite vision module.
+#
+# It runs the container image published on GitHub Container Registry (GHCR)
+# by the "Publish Docker Image" workflow (.github/workflows/publish_image.yaml).
+#
+# Usage (from this directory):
+#   docker compose up -d       # pull the image and start the server
+#   docker compose logs -f     # follow the logs
+#   docker compose down        # stop and remove the container
+#
+# See README.md ("Running the published image from GHCR") for details.
+
+services:
+  oak-d-lite-server:
+    # Image built from this folder and published on GHCR.
+    # ":main" is built from the main branch; released versions are also
+    # tagged with their semver (e.g. ":1.2.3") and ":latest".
+    image: ghcr.io/b-arol-o/freisa:main
+    container_name: oak-d-lite-server
+    # The OAK-D Lite is a USB device, so the container needs privileged
+    # access to the host USB bus (same as the vision_container.sh script).
+    privileged: true
+    device_cgroup_rules:
+      - "c 189:* rmw"
+    volumes:
+      # Give the container access to the host USB bus (the camera)
+      - /dev/bus/usb:/dev/bus/usb
+      # The image does not bundle the module code, models or config:
+      # mount this directory into the container at runtime.
+      - .:/oak-d-lite-module/
+    ports:
+      # Expose the CherryPy HTTP API (see README.md "HTTP API")
+      - "9090:9090"
+    restart: unless-stopped
+# EOF


### PR DESCRIPTION
## Summary

Closes #50.

Adds a `compose.yaml` and a HOWTO so the container image published on GHCR (`ghcr.io/b-arol-o/freisa`) by the `publish_image.yaml` workflow can actually be used — the issue asked for a `compose.yaml` "or at least a HOWTO document"; this provides both.

### What's added

- **`code/oak-d-lite-module/compose.yaml`** — runs the published GHCR image, faithfully mirroring the existing `vision_container.sh`:
  - `privileged: true` + `device_cgroup_rules: ["c 189:* rmw"]` + `/dev/bus/usb` mount for OAK-D Lite USB access
  - mounts the module directory (`.:/oak-d-lite-module/`) since the image bundles only Python deps, not the code/models/config
  - publishes port `9090` (the CherryPy HTTP API)
- **`code/oak-d-lite-module/README.md`** — new "Running the published image from GHCR" section covering:
  - the available image tags (`:main`, `:<version>`, `:latest`) and how they map to the publish workflow
  - authenticating to GHCR when the package is private (references #51)
  - running via `docker compose` (recommended) **and** an equivalent `docker run`

### Notes / decisions

- Used the canonical `compose.yaml` filename, per the Compose spec the issue cites.
- The image tag `:main` is what the workflow currently produces on pushes to `main`; `:latest`/semver tags appear only when a `v*.*.*` git tag is pushed — documented as such rather than assuming `:latest` always exists.
- Added a `docker login ghcr.io` note because the packages are currently not public (tracked in #51); this makes the HOWTO work today regardless of how #51 is resolved.

### Verification

- `prettier --check` passes on the README and `compose.yaml`.
- `yamllint` passes on `compose.yaml`.
- `docker compose -f code/oak-d-lite-module/compose.yaml config` validates successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc57S5DG9vCz16a8g7Xxqi)_