### PR TITLE
Update copyright year to 2026 in README and LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 B-AROL-O Team
+Copyright (c) 2023-2026 B-AROL-O Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Please report bugs and feature requests on <https://github.com/B-AROL-O/FREISA/i
 
 ## Copyright and license
 
-Copyright (C) 2023-2025, [B-AROL-O Team](https://github.com/B-AROL-O), all rights reserved.
+Copyright (C) 2023-2026, [B-AROL-O Team](https://github.com/B-AROL-O), all rights reserved.
 
 ### Source code license
 


### PR DESCRIPTION
## Summary

- Updates the copyright year range from `2023-2025` to `2023-2026` in `README.md`'s "Copyright and license" section.
- Updates the copyright year from `2023` to `2023-2026` in the root `LICENSE` (MIT) file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc57S5DG9vCz16a8g7Xxqi)_