### PR TITLE
Add FREISA-GPT architecture diagram and documentation (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ FREISA-GPT transforms the original FREISA robotic dog into an **intelligent assi
   </a>
 </p>
 
+### FREISA-GPT architecture
+
+For a description of how the voice pipeline, the LLM, the MCP server and the robot fit together, see the [FREISA-GPT architecture](/docs/freisa-gpt-architecture.md).
+
 ### How to run FREISA-GPT
 
 To run FREISA-GPT with an emulated version of the pupper, check out the [guide](/docs/howto/howto-run-freisa-gpt.md).

--- a/code/FREISA-GPT/README.md
+++ b/code/FREISA-GPT/README.md
@@ -8,4 +8,6 @@ Composed of:
 - **MCP Server**, based on [ros-mcp-server](https://github.com/robotmcp/ros-mcp-server), exposing tools to control the ROS2-based [mini-pupper](https://www.kickstarter.com/projects/mdrobotkits/mini-pupper-2-open-source-ros2-robot-kit-for-dreamers) robot, based on the LLM responses.
   - The MCP server is launched by the client.
 
+See the [FREISA-GPT architecture](/docs/freisa-gpt-architecture.md) for a diagram of how these components fit together.
+
 For usage, check out the [howto](/docs/howto/howto-run-freisa-gpt.md), which provides a local setup guide to emulate the robot.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # FREISA public documentation
 
+- [FREISA-GPT architecture](freisa-gpt-architecture.md)
 - [FREISA HOWTOs](howto/)
 - [FREISA REST APIs](apis.md)
 

--- a/docs/freisa-gpt-architecture.md
+++ b/docs/freisa-gpt-architecture.md
@@ -1,0 +1,138 @@
+# FREISA-GPT architecture
+
+This document describes the architecture of [FREISA-GPT](/code/FREISA-GPT), the
+voice-driven, LLM-powered evolution of Project FREISA presented at the
+[OpenAI Open Model Hackathon](https://devpost.com/software/todo-hsifwn).
+
+FREISA-GPT lets a human talk to the Mini Pupper 2 robot dog in plain language.
+A local speech-to-text stage turns the voice command into text, an open-weight
+LLM ([`gpt-oss:20b`](https://openai.com/index/introducing-gpt-oss/)) decides
+which robot capability to invoke, and the resulting tool call is executed on the
+robot through ROS 2. In parallel, the puppy shows what it is doing through
+facial expressions and sounds.
+
+## Component overview
+
+```mermaid
+flowchart LR
+    user(["User<br/>(voice command)"])
+
+    subgraph client["MCP Client — code/FREISA-GPT"]
+        direction TB
+        va["PuppyVoiceAssistant<br/><i>sounddevice + webrtcvad</i>"]
+        stt["Whisper STT<br/><i>pywhispercpp / whisper.cpp</i>"]
+        cs["ChatSession<br/><i>mcp_client.py</i>"]
+        pa["parse_action<br/><i>puppy_interaction.py</i>"]
+        va --> stt --> cs
+        va -.-> pa
+        cs -.-> pa
+    end
+
+    llm["LLM endpoint<br/><i>OpenWebUI — gpt-oss:20b</i>"]
+
+    subgraph server["MCP Server — src/mcp_server_pupper"]
+        direction TB
+        tools["FastMCP tools<br/><i>publish_once, subscribe_once,<br/>get_topics, ping_robot, …</i>"]
+        wsm["WebSocketManager"]
+        tools --> wsm
+    end
+
+    api["Puppy State API<br/><i>code/puppy-state-api (Flask)</i>"]
+    hw["Face LCD + speaker"]
+    rb["rosbridge_server<br/><i>ws://…:9090</i>"]
+    ros["ROS 2 Humble<br/><i>mini_pupper_bringup</i>"]
+    robot(["Mini Pupper 2<br/>(or RViz simulation)"])
+
+    user -->|"microphone audio"| va
+    cs -->|"HTTP: prompt + tool list"| llm
+    llm -->|"JSON tool_calls"| cs
+    cs -->|"MCP call_tool (stdio)"| tools
+    wsm -->|"rosbridge JSON (WebSocket)"| rb
+    rb --> ros --> robot
+    pa -->|"HTTP: /api/v1/state, /face, /sound"| api
+    api --> hw
+```
+
+| Component               | Location                                                                                                                | Role                                                                                                                                                                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MCP Client**          | [`code/FREISA-GPT`](/code/FREISA-GPT)                                                                                   | Entry point. Captures audio, transcribes it, talks to the LLM, dispatches tool calls, and drives the puppy's expressions.                                                                                              |
+| **PuppyVoiceAssistant** | [`src/mcp_client_pupper/puppy_voice_assistant.py`](/code/FREISA-GPT/src/mcp_client_pupper/puppy_voice_assistant.py)     | Speech-to-text stage: captures microphone blocks with `sounddevice`, detects speech with `webrtcvad`, and transcribes with `pywhispercpp`. Listens for the wake phrase before accepting a command.                     |
+| **ChatSession**         | [`src/mcp_client_pupper/mcp_client.py`](/code/FREISA-GPT/src/mcp_client_pupper/mcp_client.py)                           | Builds the system prompt from the MCP tool catalogue, sends the conversation to the LLM, parses the returned `tool_calls`, and routes each call to the MCP server that owns the tool.                                  |
+| **LLMClient**           | [`src/mcp_client_pupper/utils/llm_client.py`](/code/FREISA-GPT/src/mcp_client_pupper/utils/llm_client.py)               | HTTP client for an OpenWebUI-compatible endpoint (`POST /api/chat/completions`).                                                                                                                                       |
+| **MCP Server**          | [`src/mcp_server_pupper`](/code/FREISA-GPT/src/mcp_server_pupper)                                                       | [FastMCP](https://github.com/jlowin/fastmcp) server, based on [ros-mcp-server](https://github.com/robotmcp/ros-mcp-server), exposing the robot's ROS 2 interface as MCP tools. Launched as a subprocess by the client. |
+| **WebSocketManager**    | [`src/mcp_server_pupper/utils/websocket_manager.py`](/code/FREISA-GPT/src/mcp_server_pupper/utils/websocket_manager.py) | Maintains the WebSocket connection to `rosbridge` and translates tool arguments into rosbridge operations.                                                                                                             |
+| **Puppy State API**     | [`code/puppy-state-api`](/code/puppy-state-api)                                                                         | Flask HTTP server implementing the puppy [state machine](/code/puppy-state-api/puppy_state_machine_specs.md); renders faces on the LCD and plays sounds.                                                               |
+| **rosbridge / ROS 2**   | external                                                                                                                | `rosbridge_server` exposes ROS 2 topics and services over a WebSocket; `mini_pupper_bringup` drives the physical robot (or the RViz simulation).                                                                       |
+
+## Interaction flow
+
+A single voice command travels through the system as follows.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant VA as PuppyVoiceAssistant
+    participant CS as ChatSession
+    participant LLM as gpt-oss:20b
+    participant MS as MCP Server
+    participant RB as rosbridge / ROS 2
+    participant API as Puppy State API
+
+    U->>VA: "Hello puppy"
+    VA->>API: reset, state:listening
+    U->>VA: "Walk forward"
+    VA->>VA: VAD + Whisper transcription
+    VA->>API: state:thinking
+    VA->>CS: transcribed command
+    CS->>LLM: system prompt (tool catalogue) + user command
+    LLM-->>CS: JSON tool_calls
+    CS->>MS: call_tool(name, arguments) over stdio
+    MS->>RB: rosbridge publish / subscribe
+    RB-->>MS: result
+    MS-->>CS: tool result
+    CS->>LLM: tool result for a natural-language reply
+    LLM-->>CS: final response
+    CS->>API: state:wink
+    VA->>API: state:proud, then reset
+```
+
+The puppy's visible state follows the
+[state machine](/code/puppy-state-api/puppy_state_machine_specs.md) configured
+in [`puppy_config.json`](/code/puppy-state-api/puppy_config.json):
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+    idle --> listening
+    listening --> thinking
+    thinking --> wink
+    thinking --> confused
+    wink --> proud
+    confused --> listening
+    confused --> idle
+    proud --> listening
+    proud --> idle
+```
+
+## Interfaces and defaults
+
+| Link                         | Protocol                          | Default                                                                                                                           |
+| ---------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| MCP Client → LLM             | HTTP (OpenAI-compatible)          | `https://openwebui.gmacario.it`, model `gpt-oss:20b` — override with `--llm-base-url` / `--llm-model`                             |
+| MCP Client → MCP Server      | MCP over `stdio`                  | configured in [`servers_config.json`](/code/FREISA-GPT/servers_config.json); the server also supports `sse` and `streamable-http` |
+| MCP Server → rosbridge       | WebSocket (rosbridge v2 protocol) | `ws://127.0.0.1:9090`                                                                                                             |
+| MCP Client → Puppy State API | HTTP REST                         | `http://localhost:5080` — override with `--puppy-api-url`                                                                         |
+
+The wake phrase is `Hello puppy` (fuzzy-matched); the default Whisper model is
+`small.en`. Run `uv run main.py --help` in [`code/FREISA-GPT`](/code/FREISA-GPT)
+for the full list of options.
+
+## See also
+
+- [HOWTO: Run FREISA-GPT](/docs/howto/howto-run-freisa-gpt.md) — local setup
+  with an emulated robot
+- [FREISA REST APIs](/docs/apis.md)
+- [Puppy state machine specification](/code/puppy-state-api/puppy_state_machine_specs.md)
+
+<!-- EOF -->


### PR DESCRIPTION
## Summary

Closes #96.

Adds the missing FREISA-GPT architecture documentation as a new page, [`docs/freisa-gpt-architecture.md`](https://github.com/B-AROL-O/FREISA/blob/claude/freisa-gpt-architecture-96/docs/freisa-gpt-architecture.md), and links it from the places a reader is likely to start.

### What's added

`docs/freisa-gpt-architecture.md` contains three **Mermaid** diagrams plus supporting tables:

1. **Component overview** (`flowchart`) — user → voice pipeline → LLM → MCP server → rosbridge/ROS 2 → robot, with the Puppy State API branch driving faces and sounds.
2. **Interaction flow** (`sequenceDiagram`) — what happens for a single voice command, from the `Hello puppy` wake phrase through tool execution to the final state transitions.
3. **Puppy state machine** (`stateDiagram-v2`) — `idle → listening → thinking → wink/confused → proud`, as configured in `puppy_config.json`.

Plus a component table (what each module does and where it lives) and an interfaces table (protocol and default endpoint for each link: LLM, MCP stdio, rosbridge WebSocket, Puppy State API).

Links added from:

- root `README.md` — new "FREISA-GPT architecture" subsection in the FREISA-GPT block
- `docs/README.md` — documentation index
- `code/FREISA-GPT/README.md` — next to the existing component list

### Why Mermaid rather than an image

Mermaid renders natively on GitHub, is reviewable as a diff, and stays editable as the code evolves — no binary asset to regenerate. If you'd prefer to match the existing `assets/images/puppy-state-diagram-v1.excalidraw` convention, the Mermaid source can be exported to PNG/SVG and committed alongside.

### Note on the DevPost diagram

The issue references the diagram in the DevPost description. DevPost returns HTTP 403 to automated fetches, so I could not read the original image. **The diagrams here are derived directly from the current code**, which should make them accurate for `main` today — but it does mean they may differ in layout or naming from the DevPost version. Happy to adjust if you can share that image.

Sources used:

| Element in diagram | Derived from |
|---|---|
| VAD + Whisper stage, wake phrase, state transitions | `src/mcp_client_pupper/puppy_voice_assistant.py` |
| System prompt, `tool_calls` parsing, tool routing | `src/mcp_client_pupper/mcp_client.py` |
| LLM endpoint and payload | `src/mcp_client_pupper/utils/llm_client.py` |
| `state:` / `set_face:` / `play_sound:` REST calls | `src/mcp_client_pupper/utils/puppy_interaction.py` |
| FastMCP tool list, rosbridge connection | `src/mcp_server_pupper/main.py`, `utils/websocket_manager.py` |
| MCP stdio transport | `servers_config.json` |
| State machine states and transitions | `code/puppy-state-api/puppy_config.json` |
| Default ports / URLs | `code/FREISA-GPT/main.py`, `code/puppy-state-api/main.py` |

### Verification

- All three Mermaid diagrams render successfully via `@mermaid-js/mermaid-cli` v11 (no syntax errors); rendered output was inspected visually.
- `markdownlint` passes using the repo's own `.github/linters/.markdown-lint.yml`.
- `prettier --check` passes on all four changed files.
- All 12 repo-relative links in the new page were checked and resolve to existing paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc57S5DG9vCz16a8g7Xxqi)_